### PR TITLE
remove nightly dependance + use impl return type

### DIFF
--- a/apps/erudio/backend-api/src/main.rs
+++ b/apps/erudio/backend-api/src/main.rs
@@ -1,6 +1,5 @@
 #![forbid(unsafe_code)]
 #![recursion_limit = "256"]
-#![feature(future_join)]
 extern crate argon2;
 
 mod helpers;

--- a/apps/erudio/backend-api/src/routes/user/me.rs
+++ b/apps/erudio/backend-api/src/routes/user/me.rs
@@ -1,6 +1,7 @@
 use crate::routes::{AuthCtx, RspcResult};
 use backend_prisma_client::prisma::user;
-use rspc::ErrorCode;
+use rspc::{internal::specta::Type, ErrorCode};
+use serde::Serialize;
 
 user::select!(user_data {
 	two_factor_auth_settings : select {
@@ -28,7 +29,7 @@ user::select!(user_data {
 	}
 });
 
-pub(crate) async fn me(ctx: AuthCtx, _: ()) -> RspcResult<user_data::Data> {
+pub(crate) async fn me(ctx: AuthCtx, _: ()) -> RspcResult<impl Serialize + Type> {
 	ctx.db
 		.user()
 		.find_unique(user::UniqueWhereParam::IdEquals(ctx.user.id))

--- a/shared-libs/rust/session-manager/Cargo.toml
+++ b/shared-libs/rust/session-manager/Cargo.toml
@@ -12,6 +12,7 @@ redis.workspace = true
 log = "^0.4"
 hex = "^0.4"
 chrono = "^0.4"
+tokio = { version = "^1.21", features = ["macros"] }
 
 [dev-dependencies]
 tokio = { version = "^1.21", features = ["full"] }

--- a/shared-libs/rust/session-manager/src/destroy_all_sessions_for_user.rs
+++ b/shared-libs/rust/session-manager/src/destroy_all_sessions_for_user.rs
@@ -4,7 +4,7 @@ use backend_prisma_client::{
 	User,
 };
 use redis::{aio::MultiplexedConnection, AsyncCommands};
-use std::future::join;
+use tokio::join;
 
 pub async fn destroy_all_sessions_for_user(
 	db: &PrismaClient,
@@ -17,7 +17,7 @@ pub async fn destroy_all_sessions_for_user(
 		.exec()
 		.await?;
 
-	let result = join!(destroy_redis(redis, sessions), destroy_db(db, user)).await;
+	let result = join!(destroy_redis(redis, sessions), destroy_db(db, user));
 	result.0?;
 	result.1?;
 	Ok(())

--- a/shared-libs/rust/session-manager/src/init_session.rs
+++ b/shared-libs/rust/session-manager/src/init_session.rs
@@ -5,7 +5,7 @@ use backend_prisma_client::{
 };
 use chrono::{DateTime, Duration, Utc};
 use redis::{aio::MultiplexedConnection, AsyncCommands};
-use std::future::join;
+use tokio::join;
 
 pub async fn init_session(
 	db: &PrismaClient,
@@ -18,7 +18,7 @@ pub async fn init_session(
 	let encoded = hex::encode(client_secret);
 	let redis_async = init_redis(redis, &encoded, json, redis_expires_seconds);
 	let prisma_async = init_prisma(db, client_secret, &user.id);
-	let result = join!(redis_async, prisma_async).await;
+	let result = join!(redis_async, prisma_async);
 	result.0?;
 	result.1?;
 	Ok(encoded)

--- a/shared-libs/rust/session-manager/src/lib.rs
+++ b/shared-libs/rust/session-manager/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(future_join)]
 #![forbid(unsafe_code)]
 
 #[cfg(test)]


### PR DESCRIPTION
Feel free to close this if you don't like any of the changes.

I just thought you might like using `impl Serialize + Type` for the return type as it would allow you to return a Prisma Client Rust selection directly without needing to use the `select!` macro in the global scope. It would be nice if an `impl Trait` could be within a type alias but this [isn't supported yet](https://github.com/rust-lang/rust/issues/63063). For helper functions, you probably wouldn't wanna do this but if you're just mounting these functions onto the rspc builder then this could be nice.

I also made it so you can run the project on stable Rust. The `future_join` nightly feature looks really nice and will be agnostic of async runtime which is very nice for library authors but because this code is in your application code you know the async runtime is going to be Tokio so I would recommend just using `tokio::join!` so you get the extra stability of stable Rust.

There is also an error [here](https://github.com/ErudioProject/Erudio/blob/b20ee681e7e8c53573a99e12f61180239f3f6ed0/apps/erudio/backend-api/src/main.rs#L90) where your loading the `REGION_ID` from the `DATABASE_URL` environment variable and also your loading the environment variable in the rspc context function which could cause your application to crash on the first HTTP request instead of on startup like was probably intended. You also probably wanna pass the environment variables before you start doing anything.