### PR TITLE
Use proper prisma syntax

### DIFF
--- a/apps/erudio/backend-api/src/routes/user/me.rs
+++ b/apps/erudio/backend-api/src/routes/user/me.rs
@@ -31,7 +31,7 @@ user::select!(user_data {
 pub(crate) async fn me(ctx: AuthCtx, _: ()) -> RspcResult<user_data::Data> {
 	ctx.db
 		.user()
-		.find_unique(user::UniqueWhereParam::IdEquals(ctx.user.id))
+		.find_unique(user::id::equals(ctx.user.id))
 		.select(user_data::select())
 		.exec()
 		.await?


### PR DESCRIPTION
You were directly constructing the Prisma Client Rust `WhereParams`. This shouldn't be done as they are an implementation detail of the Prisma Client Rust. This is a super common mistake but I would recommend using the helpers like shown in the PR so that you don't have issues when upgrading Prisma Client Rust in the future.